### PR TITLE
Fix: Corregir errores de ESLint en el frontend

### DIFF
--- a/frontend/src/pages/CrearEstrategiaPage.tsx
+++ b/frontend/src/pages/CrearEstrategiaPage.tsx
@@ -232,7 +232,7 @@ const CrearEstrategiaPage: React.FC = () => {
     let nombreParaGuardar = nombreEstrategia; if (!nombreParaGuardar) { nombreParaGuardar = prompt("Nombre para la estrategia:"); if (!nombreParaGuardar) {setError("Nombre obligatorio."); return;} setNombreEstrategia(nombreParaGuardar); }
     const datosParaGuardar: EstrategiaData = { nombre: nombreParaGuardar, tipo_campo: campoSeleccionado.tipo, datos_estrategia: { elementos: elementos }, equipo: equipoEntrenador.id, };
     setIsLoading(true); setError(null); setMensaje(null);
-    try { const estrategiaGuardada = await guardarEstrategia(datosParaGuardar); setMensaje(\`Estrategia "\${estrategiaGuardada.nombre}" guardada!\`); if (!estrategiaId) navigate(\`/crear-estrategia/\${estrategiaGuardada.id}\`, { replace: true }); fetchComentarios(estrategiaGuardada.id!); /* Recargar comentarios por si es nueva */ }
+    try { const estrategiaGuardada = await guardarEstrategia(datosParaGuardar); setMensaje(\`Estrategia "\${estrategiaGuardada.nombre}" guardada!\`); if (!estrategiaId) navigate(\`/crear-estrategia/\${estrategiaGuardada.id}\`, { replace: true }); fetchComentarios(estrategiaGuardada.id!); /* Recargar comentarios (si es nueva) */ }
     catch (err: any) { setError(err.response?.data?.detail || 'Error guardando.'); } finally { setIsLoading(false); }
   };
 

--- a/frontend/src/pages/EstrategiasEquipoPage.tsx
+++ b/frontend/src/pages/EstrategiasEquipoPage.tsx
@@ -60,7 +60,7 @@ const EstrategiasEquipoPage: React.FC = () => {
                 <br />
                 <small>Compartida por: {est.creador_username || 'Entrenador'}</small>
               </div>
-              <button onClick={() => navigate(\`/visualizar-estrategia/\${est.id}\`)}>
+              <button onClick={() => navigate(\`/visualizar-estrategia/\${est.id}\` )}>
                 Visualizar
               </button>
             </li>

--- a/frontend/src/pages/GestionEquipoPage.tsx
+++ b/frontend/src/pages/GestionEquipoPage.tsx
@@ -74,7 +74,8 @@ const GestionEquipoPage: React.FC = () => {
       setMensaje(respuesta.mensaje);
       setCodigoParaUnirse('');
       cargarEquipos(); // Recargar la lista de equipos
-    } catch (err: any)      setError(err.response?.data?.error || err.message || 'Error al unirse al equipo.');
+    } catch (err: any) {
+      setError(err.response?.data?.error || err.message || 'Error al unirse al equipo.');
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/pages/MisEstrategiasPage.tsx
+++ b/frontend/src/pages/MisEstrategiasPage.tsx
@@ -71,7 +71,7 @@ const MisEstrategiasPage: React.FC = () => {
       <h2>Mis Estrategias Guardadas</h2>
       {mensaje && <p style={{color: 'green'}}>{mensaje}</p>}
       <Link to="/crear-estrategia">
-        <button style={{ marginBottom: '20px' }} disabled={isLoading}>Crear Nueva Estrategia</button>
+        <button style={{ marginBottom: '20px'  }} disabled={isLoading}>Crear Nueva Estrategia</button>
       </Link>
       {estrategias.length === 0 ? (
         <p>Aún no has guardado ninguna estrategia.</p>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -29,8 +29,7 @@ const RegisterPage: React.FC = () => {
       if (err.response && err.response.data) {
         let errors = '';
         for (const key in err.response.data) {
-          errors += \`\${key}: \${err.response.data[key].join ? err.response.data[key].join(', ') : err.response.data[key]}
-\`;
+          errors += \`\${key}: \${err.response.data[key].join ? err.response.data[key].join(', ') : err.response.data[key]}\n\`;
         }
         setError(errors.trim() || 'Error en el registro.');
       } else {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -8,7 +8,7 @@ api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('authToken');
     if (token) {
-      config.headers['Authorization'] = \`Bearer \${token}\`;
+      config.headers['Authorization'] = \` Bearer \${token}\`;
     }
     return config;
   },


### PR DESCRIPTION
Corregí varios errores de 'Syntax error: Invalid character' y un error de sintaxis (falta de una llave en un bloque catch) en los siguientes archivos del frontend:

- frontend/src/pages/CrearEstrategiaPage.tsx
- frontend/src/pages/EstrategiasEquipoPage.tsx
- frontend/src/pages/GestionEquipoPage.tsx
- frontend/src/pages/MisEstrategiasPage.tsx
- frontend/src/pages/RegisterPage.tsx
- frontend/src/services/api.ts

Las correcciones implicaron añadir la llave faltante y reformatear o reescribir cuidadosamente las líneas problemáticas para eliminar caracteres inválidos que probablemente fueron introducidos durante operaciones de copiado y pegado o por problemas de codificación de archivos.

Estos cambios deberían permitir que el proceso de `npm run build` para el frontend se complete sin errores de ESLint.