### PR TITLE
feat: Implementar funcionalidad de comentarios

### DIFF
--- a/frontend/src/services/estrategiaService.ts
+++ b/frontend/src/services/estrategiaService.ts
@@ -13,6 +13,25 @@ export interface EstrategiaData {
   fecha_modificacion?: string;
 }
 
+export interface ComentarioData {
+  id?: number;
+  estrategia: number;
+  autor_username: string;
+  texto: string;
+  fecha_creacion: string;
+  autor?: number;
+}
+
+export const getComentariosPorEstrategia = async (estrategiaId: number): Promise<ComentarioData[]> => {
+  const response = await api.get<ComentarioData[]>(`/estrategias/${estrategiaId}/comentarios/`);
+  return response.data;
+};
+
+export const addComentarioAEstrategia = async (estrategiaId: number, comentarioData: { texto: string }): Promise<ComentarioData> => {
+  const response = await api.post<ComentarioData>(`/estrategias/${estrategiaId}/comentarios/`, { texto: comentarioData.texto });
+  return response.data;
+};
+
 export const guardarEstrategia = async (datosEstrategia: EstrategiaData): Promise<EstrategiaData> => {
   // Si la estrategia tiene un ID, es una actualización (PATCH o PUT)
   // Por ahora, el PDD dice que la edición es post-MVP, así que solo crearemos nuevas.


### PR DESCRIPTION
Se define la estructura de datos y los servicios necesarios en el frontend para la gestión de comentarios sobre estrategias.

Cambios realizados:
- Añadida la interfaz `ComentarioData` en `frontend/src/services/estrategiaService.ts`.
- Implementada la función `getComentariosPorEstrategia` en `frontend/src/services/estrategiaService.ts` para obtener los comentarios de una estrategia.
- Implementada la función `addComentarioAEstrategia` en `frontend/src/services/estrategiaService.ts` para añadir un nuevo comentario a una estrategia.

Verifiqué que el backend (Django) ya contaba con los modelos, serializadores, vistas y URLs necesarios para esta funcionalidad. También confirmé que la página `frontend/src/pages/CrearEstrategiaPage.tsx` ya estaba utilizando correctamente las funciones y la interfaz que se implementaron, por lo que el error de importación que me reportaste originalmente debería estar resuelto.