### PR TITLE
fix: Corregir tipo de parámetro en llamada a addComentarioAEstrategia

### DIFF
--- a/frontend/src/pages/CrearEstrategiaPage.tsx
+++ b/frontend/src/pages/CrearEstrategiaPage.tsx
@@ -252,7 +252,7 @@ const CrearEstrategiaPage: React.FC = () => {
     if (!nuevoComentario.trim() || !estrategiaId) return;
     setIsLoadingComentarios(true);
     try {
-      const comentarioAnadido = await addComentarioAEstrategia(parseInt(estrategiaId, 10), nuevoComentario);
+      const comentarioAnadido = await addComentarioAEstrategia(parseInt(estrategiaId, 10), { texto: nuevoComentario });
       setComentarios(prev => [...prev, comentarioAnadido]); // Añadir a la lista local
       setNuevoComentario(''); // Limpiar input
     } catch (err) {


### PR DESCRIPTION
Se soluciona el error de TypeScript TS2345 en `frontend/src/pages/CrearEstrategiaPage.tsx`. El error ocurría porque la función de servicio `addComentarioAEstrategia` esperaba un objeto de tipo `{ texto: string }` como segundo argumento, pero se le estaba pasando un `string` directamente.

La llamada a `addComentarioAEstrategia` ha sido modificada para pasar el cuerpo del comentario correctamente: `{ texto: nuevoComentario }`.

Adicionalmente, revisé otras llamadas a funciones de servicio en el mismo archivo para asegurar la coherencia de los tipos, sin encontrar otros problemas.