### PR TITLE
fix: Corregir tipos de manejadores de eventos en Stage de Konva

### DIFF
--- a/frontend/src/pages/CrearEstrategiaPage.tsx
+++ b/frontend/src/pages/CrearEstrategiaPage.tsx
@@ -157,7 +157,7 @@ const CrearEstrategiaPage: React.FC = () => {
 
   // Lógica del tablero (Stage MouseDown, Move, Up, DragEnd, ElementoClick, EditarTextoFicha, Eliminar, Limpiar)
   // Estas funciones deben respetar 'isReadOnly'
-  const handleStageMouseDown = (e: Konva.KonvaEventObject<MouseEvent>) => {
+  const handleStageMouseDown = (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
     if (isReadOnly || !campoSeleccionado) return;
     // ... resto de la lógica de mousedown (sin cambios funcionales mayores)
     if (e.target !== e.target.getStage()) return;
@@ -181,13 +181,13 @@ const CrearEstrategiaPage: React.FC = () => {
         const texto = prompt("Introduce la nota:"); if (texto) { const nuevaNota: ElementoTablero = { id: Konva.Util.getRandomColor(), x, y, type: 'texto_nota', textValue: texto, fontSize: 12, fill: colorHerramienta, }; setElementos(prev => [...prev, nuevaNota]); }
     }
   };
-  const handleStageMouseMove = (e: Konva.KonvaEventObject<MouseEvent>) => { if (isReadOnly || !dibujando || !puntosActuales.length) return; /* ... */
+  const handleStageMouseMove = (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => { if (isReadOnly || !dibujando || !puntosActuales.length) return; /* ... */
     const pos = e.target.getStage()?.getPointerPosition(); if (!pos) return;
     const x = pos.x / scale; const y = pos.y / scale;
     if (herramientaActual === 'linea' || herramientaActual === 'flecha') { setPuntosActuales([puntosActuales[0], puntosActuales[1], x, y]); }
     else if (herramientaActual === 'rect_zona' || herramientaActual === 'circ_zona') { setPuntosActuales([puntosActuales[0], puntosActuales[1], x, y]); }
   };
-  const handleStageMouseUp = () => { if (isReadOnly || !dibujando || !puntosActuales.length || !campoSeleccionado) return; /* ... */
+  const handleStageMouseUp = (_e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => { if (isReadOnly || !dibujando || !puntosActuales.length || !campoSeleccionado) return; /* ... */
     setDibujando(false); const id = Konva.Util.getRandomColor(); let nuevoElemento: ElementoTablero | null = null;
     if (herramientaActual === 'linea') nuevoElemento = { id, x:0, y:0, type: 'linea', points: puntosActuales, stroke: colorHerramienta, strokeWidth: grosorHerramienta };
     else if (herramientaActual === 'flecha') nuevoElemento = { id, x:0, y:0, type: 'flecha', points: puntosActuales, stroke: colorHerramienta, fill: colorHerramienta, strokeWidth: grosorHerramienta };


### PR DESCRIPTION
Se soluciona el error de TypeScript TS2322 en `frontend/src/pages/CrearEstrategiaPage.tsx`. El error ocurría porque las funciones `handleStageMouseDown`, `handleStageMouseMove` y `handleStageMouseUp` estaban tipadas para aceptar únicamente `Konva.KonvaEventObject<MouseEvent>`, pero también se asignaban a los props de eventos táctiles (`onTouchStart`, `onTouchMove`, `onTouchEnd`) del componente `Stage`, los cuales esperan `Konva.KonvaEventObject<TouchEvent>`.

Las firmas de estas funciones de manejo de eventos han sido modificadas para aceptar `Konva.KonvaEventObject<MouseEvent | TouchEvent>`. Esto las hace compatibles con ambos tipos de eventos, resolviendo la incompatibilidad de tipos.

Para `handleStageMouseUp`, la firma también se actualizó para declarar el parámetro de evento (como `_e` ya que no se utiliza en el cuerpo de la función) para mayor consistencia y corrección de tipos. El uso de `e.target.getStage()?.getPointerPosition()` dentro de los manejadores es seguro con esta unión de tipos, ya que Konva abstrae las diferencias de eventos para este método.