### PR TITLE
fix: Configurar CORS para permitir solicitudes desde el frontend

### DIFF
--- a/pizarra_tactica_project/pizarra_tactica_project/settings.py
+++ b/pizarra_tactica_project/pizarra_tactica_project/settings.py
@@ -121,8 +121,20 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
-CORS_ALLOWED_ORIGINS = ['http://localhost:3000']
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:3000',
+    'http://192.168.20.71',
+]
 CORS_ALLOW_CREDENTIALS = True
+
+# CSRF_TRUSTED_ORIGINS es importante para permitir peticiones POST/PUT/PATCH desde orígenes externos
+# especialmente si estás usando session-based authentication o cookies CSRF.
+# Para APIs basadas en tokens (como JWT), esto podría no ser estrictamente necesario si las cookies CSRF no se usan para autenticación.
+# Sin embargo, incluirlo es una buena práctica para cubrir todos los casos.
+CSRF_TRUSTED_ORIGINS = [
+    'http://localhost:3000', # Si tu frontend también puede ser servido desde localhost para Django
+    'http://192.168.20.71',
+]
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (


### PR DESCRIPTION
He configurado `django-cors-headers` para solucionar problemas de CORS (Cross-Origin Resource Sharing) que impedían la comunicación entre tu frontend y el backend cuando se acceden desde dominios/puertos diferentes.

Cambios:
- Verifiqué que `django-cors-headers` ya estaba en `pizarra_tactica_project/requirements.txt`.
- Actualicé `pizarra_tactica_project/pizarra_tactica_project/settings.py`:
    - Confirmé que `corsheaders` está en `INSTALLED_APPS`.
    - Confirmé que `corsheaders.middleware.CorsMiddleware` está en `MIDDLEWARE`.
    - Actualicé `CORS_ALLOWED_ORIGINS` para incluir `'http://192.168.20.71'` (además del preexistente `'http://localhost:3000'`).
    - Añadí `CSRF_TRUSTED_ORIGINS` con ambos orígenes (`'http://192.168.20.71'` y `'http://localhost:3000'`) para permitir peticiones POST si la protección CSRF está activa para ellas.

Estos cambios aseguran que el backend de Django envíe las cabeceras `Access-Control-Allow-Origin` apropiadas, permitiendo así que tu frontend (servido en `http://192.168.20.71`) realice solicitudes a la API del backend.