### PR TITLE
Here's what I did to address the issues you pointed out:

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -45,6 +45,7 @@ const LoginPage: React.FC = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
+            autoComplete="current-password"
           />
         </div>
         {error && <p style={{ color: 'red' }}>{error}</p>}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -53,11 +53,11 @@ const RegisterPage: React.FC = () => {
         </div>
         <div>
           <label htmlFor="password">Contraseña:</label>
-          <input type="password" id="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+          <input type="password" id="password" value={password} onChange={(e) => setPassword(e.target.value)} required autoComplete="new-password" />
         </div>
         <div>
           <label htmlFor="password2">Confirmar Contraseña:</label>
-          <input type="password" id="password2" value={password2} onChange={(e) => setPassword2(e.target.value)} required />
+          <input type="password" id="password2" value={password2} onChange={(e) => setPassword2(e.target.value)} required autoComplete="new-password" />
         </div>
         <div>
           <label htmlFor="rol">Soy un:</label>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://localhost:8000/api', // URL base de tu API Django
+  baseURL: 'http://192.168.20.71:8000/api', // URL base de tu API Django
 });
 
 api.interceptors.request.use(


### PR DESCRIPTION
1.  **Corrected the API base URL:**
    *   I updated the `baseURL` in `frontend/src/services/api.ts` from `http://localhost:8000/api` to `http://192.168.20.71:8000/api`.
    *   This fixes the `net::ERR_CONNECTION_REFUSED` error that was happening when you accessed the frontend from a specific IP (`192.168.20.71`) while the API was still pointing to `localhost`.

2.  **Added `autocomplete` attributes to password fields:**
    *   In `frontend/src/pages/LoginPage.tsx`, I added `autoComplete="current-password"` to the password field.
    *   In `frontend/src/pages/RegisterPage.tsx`, I added `autoComplete="new-password"` to the password fields (both the main one and the confirmation).
    *   This gets rid of the DOM warnings and makes things smoother for you when using password managers.