### PR TITLE
fix: Actualizar ALLOWED_HOSTS en Django para permitir acceso por IP

### DIFF
--- a/pizarra_tactica_project/pizarra_tactica_project/settings.py
+++ b/pizarra_tactica_project/pizarra_tactica_project/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-9(&3g#(el+7cc%7(dkez-vei@wyil+kr5_0%0!^#duen3mkzxp
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['192.168.20.71']
 
 
 # Application definition


### PR DESCRIPTION
He solucionado el error `DisallowedHost` (HTTP 400 Bad Request) que ocurría al realizar peticiones a tu API de Django. El problema se debía a que la IP `192.168.20.71`, desde la cual accedías al frontend y hacías las peticiones, no estaba incluida en la lista `ALLOWED_HOSTS` en el archivo `settings.py` de tu proyecto Django.

He modificado `pizarra_tactica_project/pizarra_tactica_project/settings.py` para añadir `'192.168.20.71'` a la lista `ALLOWED_HOSTS`.