### PR TITLE
fix: Corregir asignación de rol durante el registro de usuarios

### DIFF
--- a/pizarra_tactica_project/api/serializers.py
+++ b/pizarra_tactica_project/api/serializers.py
@@ -13,9 +13,27 @@ class UsuarioSerializer(serializers.ModelSerializer):
 
 
     def create(self, validated_data):
-        # Hashea la contraseña antes de guardar el usuario
-        validated_data['password'] = make_password(validated_data.get('password'))
-        return super(UsuarioSerializer, self).create(validated_data)
+        # El campo 'rol' es manejado explícitamente. Otros campos como first_name, last_name
+        # se pasarán a create_user si están en validated_data.
+        # 'email' y 'username' son requeridos por create_user.
+        # 'password' también es requerido y create_user se encarga de hashearlo.
+
+        # Extraer 'rol' de validated_data. Si no está, create_user usará el default del modelo.
+        # Sin embargo, como 'rol' está en Meta.fields, debería estar en validated_data si se envía.
+        rol_data = validated_data.pop('rol', None)
+
+        # Crear el usuario usando el manager para asegurar el hasheo de contraseña y otros defaults.
+        # Los campos como first_name, last_name, etc., que están en validated_data
+        # y son aceptados por el modelo Usuario se pasarán.
+        user = Usuario.objects.create_user(**validated_data)
+
+        # Si se proporcionó un 'rol' específico en la solicitud y es válido, asignarlo.
+        # Si no, el 'default' del modelo ('jugador') ya se habrá aplicado durante create_user.
+        if rol_data:
+            user.rol = rol_data
+            user.save(update_fields=['rol']) # Guardar solo el campo rol actualizado
+
+        return user
 
 class ComentarioSerializer(serializers.ModelSerializer):
     autor_username = serializers.ReadOnlyField(source='autor.username')


### PR DESCRIPTION
He solucionado un problema donde los usuarios que se registraban como 'entrenador' eran incorrectamente asignados con el rol de 'jugador'.

La causa principal, aunque sutil, parecía estar en cómo se procesaba el campo 'rol' durante la creación del usuario en el backend. Para asegurar la correcta asignación y seguir las mejores prácticas de Django, he modificado el método `create` del `UsuarioSerializer` (`pizarra_tactica_project/api/serializers.py`):

- Ahora se utiliza `Usuario.objects.create_user()` para la creación de la instancia del usuario. Este método maneja adecuadamente el hasheo de contraseñas y otros valores por defecto del modelo `AbstractUser`.
- El `rol` enviado desde el frontend (que confirmé que se envía correctamente) se extrae de `validated_data` y se asigna explícitamente al usuario después de su creación inicial con `create_user()`. Si no se proporciona un rol (lo cual no debería ocurrir con el flujo actual del frontend), el `default` del modelo ('jugador') se aplicaría.

Este cambio asegura que el rol que seleccionas en el formulario de registro se persista correctamente en la base de datos.

También verifiqué que la lógica en `EquipoListCreateView` para permitir la creación de equipos solo a entrenadores es correcta y funcionará como se espera una vez que el rol se asigne adecuadamente.